### PR TITLE
added qint64 snippets found in my old log4qt version

### DIFF
--- a/src/log4qt/helpers/factory.cpp
+++ b/src/log4qt/helpers/factory.cpp
@@ -253,6 +253,8 @@ namespace Log4Qt
             value = OptionConverter::toBoolean(rValue, &ok);
         else if (type == QLatin1String("int"))
             value = OptionConverter::toInt(rValue, &ok);
+        else if (type == QLatin1String("qint64") || type == QLatin1String("qlonglong"))
+            value = OptionConverter::toQInt64(rValue, &ok);
         else if (type == QLatin1String("Log4Qt::Level"))
             value = QVariant::fromValue(OptionConverter::toLevel(rValue, &ok));
         else if (type == QLatin1String("QString"))

--- a/src/log4qt/helpers/optionconverter.cpp
+++ b/src/log4qt/helpers/optionconverter.cpp
@@ -232,6 +232,20 @@ namespace Log4Qt
         return 0;
     }
     
+    qint64 OptionConverter::toQInt64(const QString &rOption, 
+      bool *p_ok)
+    {
+      int value = rOption.trimmed().toLongLong(p_ok);
+      if (*p_ok)
+        return value;
+
+      LogError e = LOG4QT_ERROR(QT_TR_NOOP("Invalid option string '%1' for an qint64"), 
+        CONFIGURATOR_INVALID_OPTION_ERROR,
+        "Log4Qt::OptionConverter");
+      e << rOption;
+      logger()->error(e);
+      return 0;
+    }
     
     Level OptionConverter::toLevel(const QString &rOption, 
                                    bool *p_ok)

--- a/src/log4qt/helpers/optionconverter.h
+++ b/src/log4qt/helpers/optionconverter.h
@@ -95,6 +95,15 @@ namespace Log4Qt
                          bool *p_ok = 0);
         
         /*!
+          * Converts the option \a rOption to a qint64 value using 
+          * QString::toLongLong(). If the conversion is successful, the qint64 is 
+          * returned and \a p_ok is set to true. Otherwise an error is written
+          * to the log, \a p_ok is set to false and 0 is returned.
+          */
+        static qint64 toQInt64(const QString &rOption,
+                               bool *p_ok = 0);
+
+        /*!
          * Converts the option \a rOption to a level value using 
          * Level::fromString(). If the conversion is successful, the level 
          * is returned and \a p_ok is set to true. Otherwise an error is 


### PR DESCRIPTION
I found these parts in my very old log4qt version. As the are missing in original code base, I probably added them myself some time in the past. They are needed for example to use maximumFileSize property for RollingFileAppender.
